### PR TITLE
Fix typo on "Connection dropped"

### DIFF
--- a/lib/server/balancer/utils.js
+++ b/lib/server/balancer/utils.js
@@ -158,7 +158,7 @@ Balancer._proxyWeb = function _proxyWeb(req, res, endpoint, cookies, retries) {
     // And it's possible to have we've already send headers and data
     // So, we don't simply retry here. Let it handle by the client
     // We can't also send 500 error because of the above issue
-    printError("Connection droped", true);
+    printError("Connection dropped", true);
 
     function printError(message, dontSendHeaders) {
       message = message || error.message;


### PR DESCRIPTION
Just picking up on a typo/spelling mistake: "Connection droped" now "Connection dropped".