### PR TITLE
Fix a bug in cordova: Meteor app hosted in Cordova can't connect to c…

### DIFF
--- a/lib/client/api.js
+++ b/lib/client/api.js
@@ -1,3 +1,12 @@
-Cluster.discoverConnection = function(serviceName) {
-  return DDP.connect("/" + serviceName);
+Cluster.discoverConnection = function(serviceName, ddpOptions) {
+  var url;
+
+  // use Meteor.absoluteUrl() to construct url by default, just for supporting cordova.
+  if (!ddpOptions || ddpOptions.useAbsoluteUrl) {
+    url = Meteor.absoluteUrl(serviceName);
+  } else {
+    url = "/" + serviceName;
+  }
+
+  return DDP.connect(url);
 };

--- a/package.js
+++ b/package.js
@@ -17,6 +17,8 @@ Npm.depends({
 Package.onTest(function(api) {
   configurePackage(api);
   api.use('tinytest');
+  api.use('mongo');
+  api.use('random');
   api.use('practicalmeteor:sinon@1.10.3_2');
 
   api.addFiles([

--- a/package.js
+++ b/package.js
@@ -1,6 +1,6 @@
 Package.describe({
   "summary": "Clustering solution for Meteor with load balancing and service discovery.",
-  "version": "1.6.9",
+  "version": "1.7.0",
   "git": "https://github.com/meteorhacks/cluster.git",
   "name": "meteorhacks:cluster"
 });


### PR DESCRIPTION
lib/client/api.js: use Meteor.absoluteUrl() to construct url by default, just for supporting cordova.
package.js: ver 1.6.9 => ver 1.7.0
