### PR TITLE
Buffer() -> Buffer.from() caused by Deprecated.

### DIFF
--- a/lib/server/balancer/workers.js
+++ b/lib/server/balancer/workers.js
@@ -6,7 +6,7 @@ var workers = null;
 process.on("message", function(message, socket) {
   if(message.type === "proxy-ws") {
     var httpServer = Package.webapp.WebApp.httpServer;
-    var head = new Buffer(message.head);
+    var head = new Buffer.from(message.head);
     httpServer.emit("upgrade", message.req, socket, head);
   }
 });


### PR DESCRIPTION
Changed deprecated buffer() API.